### PR TITLE
Correção de teste de métodos get

### DIFF
--- a/tests/ComponenteCurricularTest.php
+++ b/tests/ComponenteCurricularTest.php
@@ -146,30 +146,72 @@ class ComponenteCurricularTest extends TestCase
 
         $contentType = $response->getHeaders()["Content-Type"][0];
         $this->assertEquals("application/json; charset=UTF-8", $contentType);
+
+        $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentBody = $response->getBody()->getContents();
+       
+        $componenteArray = [ "nome"=> "Cálculo I",
+                "codCompCurric"=> 1,
+                "periodo"=> 1,
+                "credito"=> 5,
+                "codDepto"=> 2,
+                "depto"=> "DMA",
+                "numDisciplina"=> 5670,
+                "codPpc"=> 1];
+
+        $componenteJson = json_encode($componenteArray);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals("application/json; charset=UTF-8", $contentType);
+        $this->assertContains($componenteJson, $contentBody);
     }
 
     public function testGetComponente()
     {
         $response = $this->http->request('GET', 'componentes-curriculares/1', ['http_errors' => FALSE] );
 
-        $this->assertEquals(200, $response->getStatusCode());
-
         $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentBody = $response->getBody()->getContents();
+       
+        $componenteArray = [ "nome"=> "Cálculo I",
+                    "codCompCurric"=> 1,
+                    "ch"=> 75,
+                    "periodo"=> 1,
+                    "credito"=> 5,
+                    "codDepto"=> 2,
+                    "depto"=> "DMA",
+                    "numDisciplina"=> 5670,
+                    "codPpc"=> 1];
+
+        $componenteJson = json_encode($componenteArray);
+
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("application/json; charset=UTF-8", $contentType);
+        $this->assertJsonStringEqualsJsonString($componenteJson, $contentBody);
     }
 
     public function testGetComponentesPpc()
     {
         $response = $this->http->request('GET', 'projetos-pedagogicos-curso/1/componentes-curriculares', ['http_errors' => FALSE] );
 
-        $this->assertEquals(200, $response->getStatusCode());
-
         $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentBody = $response->getBody()->getContents();
+       
+        $componenteArray = [ "codCompCurric"=> 1,
+                    "nome"=> "Cálculo I",
+                    "ch"=> 75,
+                    "tipo"=> "OBRIGATORIA",
+                    "periodo"=> 1];
+
+        $componenteJson = json_encode($componenteArray);
+
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("application/json; charset=UTF-8", $contentType);
+        $this->assertContains($componenteJson, $contentBody);
     }
     
-    // Testes POST
 
+    // Testes POST
     public function testPostComponente()
     {
         $response = $this->http->request('POST', 'componentes-curriculares', 
@@ -191,8 +233,8 @@ class ComponenteCurricularTest extends TestCase
         $this->assertJsonStringEqualsJsonString($message,$contentBody);
     }
 
-    // Teste PUT
 
+    // Teste PUT
     public function testPutComponente()
     {
         $response = $this->http->request('PUT', 'componentes-curriculares/221', 
@@ -214,26 +256,23 @@ class ComponenteCurricularTest extends TestCase
         $this->assertJsonStringEqualsJsonString($message,$contentBody);
     }
 
+
     // Teste DELETE
+    public function testDeleteComponente()
+    {
+        $response = $this->http->request('DELETE', 'componentes-curriculares/227', ['http_errors' => FALSE] );
 
-    // public function testDeleteComponente()
-    // {
-    //     $response = $this->http->request('DELETE', 'componentes-curriculares/227', ['http_errors' => FALSE] );
+        $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentBody = $response->getBody()->getContents();
+        $message = $this->getStdMessage(self::DELETED);
 
-    //     $contentType = $response->getHeaders()["Content-Type"][0];
-    //     $contentBody = $response->getBody()->getContents();
-    //     $message = $this->getStdMessage(self::DELETED);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals("application/json; charset=UTF-8", $contentType);
+        $this->assertJsonStringEqualsJsonString($message,$contentBody);
+    }
 
-    //     $this->assertEquals(200, $response->getStatusCode());
-    //     $this->assertEquals("application/json; charset=UTF-8", $contentType);
-    //     $this->assertJsonStringEqualsJsonString($message,$contentBody);
-    // }
-
-
-    // Teste de erros GET
 
     // Testes por ppc não existente ou não encontrado
-
     public function testGetComponentesPpcNaoExistente()
     {
         $response = $this->http->request('GET', 'projetos-pedagogicos-curso/1234/componentes-curriculares', ['http_errors' => FALSE] );
@@ -338,10 +377,8 @@ class ComponenteCurricularTest extends TestCase
         $this->assertJsonStringEqualsJsonString($message,$contentBody);
     }
 
-    // teste departamento não existente
 
-    // Testes por disciplina não existente ou não encontrada
-    
+    // Testes por disciplina não existente ou não encontrada 
     public function testPostComponenteDisciplinaNaoExistente()
     {
         $response = $this->http->request('POST', 'componentes-curriculares', 
@@ -384,8 +421,8 @@ class ComponenteCurricularTest extends TestCase
         $this->assertJsonStringEqualsJsonString($message,$contentBody);
     }
 
-    //  Teste por período de valor inválido
 
+    //  Teste por período de valor inválido
     public function testPostComponentePeriodoInvalido()
     {
         $response = $this->http->request('POST', 'componentes-curriculares', 
@@ -423,8 +460,8 @@ class ComponenteCurricularTest extends TestCase
         $this->assertJsonStringEqualsJsonString($message,$contentBody);
     }
 
-    // Teste por crédito de valor inválido
 
+    // Teste por crédito de valor inválido
     public function testPostComponenteCreditoInvalido()
     {
         $response = $this->http->request('POST', 'componentes-curriculares', 
@@ -464,7 +501,6 @@ class ComponenteCurricularTest extends TestCase
 
 
     // Teste por tipo de valor inválido
-
     public function testPostComponenteTipoInvalido()
     {
         $response = $this->http->request('POST', 'componentes-curriculares', 
@@ -502,8 +538,8 @@ class ComponenteCurricularTest extends TestCase
         $this->assertJsonStringEqualsJsonString($message,$contentBody);
     }
 
-    // Teste valores NULL
 
+    // Teste valores NULL
     public function testPostComponenteValoresNull()
     {
         $response = $this->http->request('POST', 'componentes-curriculares', 

--- a/tests/CorrespondenciaTest.php
+++ b/tests/CorrespondenciaTest.php
@@ -140,34 +140,71 @@ class CorrespondenciaTest extends TestCase
     // Testes de comportamento normal
 
     // Teste de rotas GET
-    public function testGetAllCorrespondencia()
+    public function testGetAllCorrespondencias()
     {
         $response = $this->http->request('GET', 'correspondencias', ['http_errors' => FALSE] );
 
-        $this->assertEquals(200, $response->getStatusCode());
-
         $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentBody = $response->getBody()->getContents();
+       
+        $correspondencia = [ "codCompCurric"=> 1,
+                    "depto"=> "DMA",
+                    "numDisciplina"=> 5670,
+                    "NomeDisciplina"=> "Cálculo I",
+                    "codCompCorresp"=> 58,
+                    "deptoDisciplinaCorresp"=> "DMA",
+                    "numDisciplinaCorresp"=> 96,
+                    "NomeDisciplinaCorresp"=> "Cálculo I",
+                    "percentual"=> 1];
+
+        $correspondenciaJson = json_encode($correspondencia);
+
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("application/json; charset=UTF-8", $contentType);
+        $this->assertContains($correspondenciaJson, $contentBody);
     }
 
     public function testGetCorrespondenciasPpc()
     {
         $response = $this->http->request('GET', 'projetos-pedagogicos-curso/1/correspondencias/2', ['http_errors' => FALSE] );
 
-        $this->assertEquals(200, $response->getStatusCode());
-
         $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentBody = $response->getBody()->getContents();
+       
+        $correspondencia = [ "codCompCurric"=> 1,
+                "codCompCorresp"=> 58,
+                "percentual"=> 1];
+
+        $correspondenciaJson = json_encode($correspondencia);
+
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("application/json; charset=UTF-8", $contentType);
+        $this->assertContains($correspondenciaJson, $contentBody);
+
     }
 
     public function testGetCorrespondenciaComponentes()
     {
         $response = $this->http->request('GET', 'componentes-curriculares/1/correspondencias/58', ['http_errors' => FALSE] );
 
-        $this->assertEquals(200, $response->getStatusCode());
-
         $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentBody = $response->getBody()->getContents();
+       
+        $correspondencia = [ "codCompCurric" =>1,
+                "depto" => "DMA",
+                "numDisciplina" => 5670,
+                "NomeDisciplina" => "Cálculo I",
+                "codCompCorresp" => 58,
+                "deptoDisciplinaCorresp" => "DMA",
+                "numDisciplinaCorresp" => 96,
+                "NomeDisciplinaCorresp" => "Cálculo I",
+                "percentual" => 1];
+
+        $correspondenciaJson = json_encode($correspondencia);
+
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("application/json; charset=UTF-8", $contentType);
+        $this->assertJsonStringEqualsJsonString($correspondenciaJson, $contentBody);
     }
 
 
@@ -217,18 +254,6 @@ class CorrespondenciaTest extends TestCase
         $this->assertJsonStringEqualsJsonString($message,$contentBody);
     }
 
-
-    // Testes de erros
-    // Teste de erro por correspondência não encontrada
-    // public function testGetCorrespondenciaNaoExistente()
-    // {
-    //     $response = $this->http->request('GET', 'correspondencias', ['http_errors' => FALSE] );
-
-    //     $this->assertEquals(404, $response->getStatusCode());
-
-    //     $contentType = $response->getHeaders()["Content-Type"][0];
-    //     $this->assertEquals("application/json; charset=UTF-8", $contentType);
-    // }
 
     // Teste de erro por Ppc não existente
     public function testGetCorrespondenciaPpcNaoExistente()

--- a/tests/TransicaoTest.php
+++ b/tests/TransicaoTest.php
@@ -126,14 +126,23 @@ class TransicaoTest extends TestCase
     // Testes de comportamento normal
 
     // Teste de rotas GET
-    public function testGetTransicao()
+    public function testGetAllTransicoes()
     {
         $response = $this->http->request('GET', 'transicoes', ['http_errors' => FALSE] );
 
-        $this->assertEquals(200, $response->getStatusCode());
-
         $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentBody = $response->getBody()->getContents();
+       
+        $transicao = [ "ppcAtual"=> "Ciência da Computação (2011)",
+                    "codPpcAtual"=> 1,
+                    "ppcAlvo"=> "Ciência da Computação (2019)",
+                    "codPpcAlvo"=> 2];
+
+        $transicaoJson = json_encode($transicao);
+
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("application/json; charset=UTF-8", $contentType);
+        $this->assertContains($transicaoJson, $contentBody);
         
     }
 
@@ -141,20 +150,35 @@ class TransicaoTest extends TestCase
     {
         $response = $this->http->request('GET', 'projetos-pedagogicos-curso/1/transicoes', ['http_errors' => FALSE] );
 
-        $this->assertEquals(200, $response->getStatusCode());
-
         $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentBody = $response->getBody()->getContents();
+       
+        $transicao = [ "ppcAtual"=> "Ciência da Computação (2011)",
+                    "codPpcAtual"=> 1,
+                    "ppcAlvo"=> "Ciência da Computação (2019)",
+                    "codPpcAlvo"=> 2];
+
+        $transicaoJson = json_encode($transicao);
+
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("application/json; charset=UTF-8", $contentType);
+        $this->assertContains($transicaoJson, $contentBody);
     }
 
     public function testGetTransicaoUnidadeEnsino()
     {
         $response = $this->http->request('GET', 'unidades-ensino/1/transicoes', ['http_errors' => FALSE] );
 
-        $this->assertEquals(200, $response->getStatusCode());
-
         $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentBody = $response->getBody()->getContents();
+       
+        $transicao = ["nomeCurso"=> "Ciência da Computação (2011)", "codPpc"=> 1];
+
+        $transicaoJson = json_encode($transicao);
+
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("application/json; charset=UTF-8", $contentType);
+        $this->assertContains($transicaoJson, $contentBody);
     }
 
 


### PR DESCRIPTION
Corrigidos testes de métodos get de correspondência, componente curricular e transição.
Agora os testes verificam se um exemplo da resposta está presente no array